### PR TITLE
Update instance-list-volumes command

### DIFF
--- a/power-iaas-cli.md
+++ b/power-iaas-cli.md
@@ -514,7 +514,7 @@ Use these release notes to learn about the latest changes to the {{site.data.key
 #### Get a list of volumes attached to an instance
 {: #get-list-vol}
 
-`ibmcloud pi volume INSTANCE [--long] [--json]`
+`ibmcloud pi instance-list-volumes INSTANCE [--long] [--json]`
 
 **Options**
 


### PR DESCRIPTION
It just said "volume" which errors out and does not list the volumes. Updated the example with the correct command